### PR TITLE
Fix projects page footer glitch

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -80,6 +80,7 @@ a: visited { color: #555; }
 #home-post ul {
   list-style: none;
   margin-top: 10px;
+  margin-bottom: 10px;
 }
 #home-post ul li {
   margin-top: 10px;


### PR DESCRIPTION
This is caused by the `ul` not wrapping the content correctly (too short), so the image ended up taking more vertical space. The simple fix is to give a bottom margin to the `ul` too.

Small side effect is that it makes the top and bottom spacing for each item look more consistent.